### PR TITLE
[feat] - Add result page to show submitted bookmark

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,9 +1,14 @@
 import { Routes } from '@angular/router';
 import { BookmarkComponent } from './features/bookmark/bookmark.component';
+import { BookmarkResultComponent } from './features/bookmark/components/bookmark-result/bookmark-result.component';
 
 export const routes: Routes = [
   {
     path: '',
     component: BookmarkComponent,
   },
+  {
+    path: 'result',
+    component: BookmarkResultComponent
+  }
 ];

--- a/src/app/features/bookmark/components/bookmark-form/bookmark-form.component.ts
+++ b/src/app/features/bookmark/components/bookmark-form/bookmark-form.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { Bookmark } from '../../bookmark.model';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-bookmark-form',
@@ -24,7 +25,12 @@ export class BookmarkFormComponent {
   urlExists: boolean | null = null;
   isCheckingUrl = false;
 
-  constructor(private fb: FormBuilder) {
+  // Constructor initializes the form group with title and URL fields.
+  // The FormBuilder service is used to create the form group and its controls.
+  // The form is reactive, allowing for dynamic validation and state management.
+  // The URL field has a custom validator to check its format.
+  // The router is injected to navigate to the result page after submission.
+  constructor(private fb: FormBuilder, private router: Router)  {
     this.form = this.fb.group({
       title: ['', Validators.required],
       url: ['', [Validators.required, this.validateUrlFormat]],
@@ -114,5 +120,10 @@ export class BookmarkFormComponent {
     this.bookmarkAdded.emit(newBookmark);
     this.form.reset();
     this.urlExists = null;
+
+    this.router.navigate(['/result'], {
+      state: { bookmark: newBookmark },
+    });
   }
+
 }

--- a/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.html
+++ b/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.html
@@ -1,0 +1,10 @@
+<div *ngIf="bookmark; else noData">
+  <h2>✅ Thank you for your submission!</h2>
+  <p><strong>Title:</strong> {{ bookmark.title }}</p>
+  <p><strong>URL:</strong> <a [href]="bookmark.url" target="_blank" rel="noopener">{{ bookmark.url }}</a></p>
+  <button (click)="goBack()">← Back to Bookmark Manager</button>
+</div>
+
+<ng-template #noData>
+  <p>No bookmark submitted. <a routerLink="/">Return home</a>.</p>
+</ng-template>

--- a/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
+++ b/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BookmarkResultComponent } from './bookmark-result.component';
+
+describe('BookmarkResultComponent', () => {
+  let component: BookmarkResultComponent;
+  let fixture: ComponentFixture<BookmarkResultComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BookmarkResultComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BookmarkResultComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
+++ b/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
@@ -8,6 +8,7 @@ describe('BookmarkResultComponent', () => {
   let component: BookmarkResultComponent;
   let fixture: ComponentFixture<BookmarkResultComponent>;
 
+  // Mock bookmark used to simulate router navigation state
   const mockBookmark: Bookmark = {
     id: '1',
     title: 'Test Bookmark',
@@ -15,6 +16,7 @@ describe('BookmarkResultComponent', () => {
     createdAt: new Date().toISOString(),
   };
 
+  // Mock router navigation state to inject the bookmark as route state
   const mockNavigation = {
     extras: {
       state: {
@@ -27,6 +29,7 @@ describe('BookmarkResultComponent', () => {
     await TestBed.configureTestingModule({
       imports: [BookmarkResultComponent],
       providers: [
+        // Inject mocked router and location services
         { provide: Router, useValue: { getCurrentNavigation: () => mockNavigation } },
         { provide: Location, useValue: { back: jasmine.createSpy('back') } },
       ],
@@ -41,15 +44,20 @@ describe('BookmarkResultComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display the thank you message', () => {
+  it('should display the thank you message and bookmark details', () => {
     const compiled = fixture.nativeElement as HTMLElement;
+
+    // Ensure the message and submitted bookmark details appear in the DOM
     expect(compiled.textContent).toContain('Thank you for your submission');
     expect(compiled.textContent).toContain('Test Bookmark');
     expect(compiled.textContent).toContain('https://example.com');
   });
 
-  it('should call location.back() when goBack is triggered', () => {
+  it('should call location.back() when goBack() is invoked', () => {
+    // Trigger the back navigation
     component.goBack();
+
+    // Verify the Location service's back method was called
     const location = TestBed.inject(Location);
     expect(location.back).toHaveBeenCalled();
   });

--- a/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
+++ b/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.spec.ts
@@ -1,23 +1,56 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { BookmarkResultComponent } from './bookmark-result.component';
+import { Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { Bookmark } from '../../bookmark.model';
 
 describe('BookmarkResultComponent', () => {
   let component: BookmarkResultComponent;
   let fixture: ComponentFixture<BookmarkResultComponent>;
 
+  const mockBookmark: Bookmark = {
+    id: '1',
+    title: 'Test Bookmark',
+    url: 'https://example.com',
+    createdAt: new Date().toISOString(),
+  };
+
+  const mockNavigation = {
+    extras: {
+      state: {
+        bookmark: mockBookmark,
+      },
+    },
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BookmarkResultComponent]
-    })
-    .compileComponents();
+      imports: [BookmarkResultComponent],
+      providers: [
+        { provide: Router, useValue: { getCurrentNavigation: () => mockNavigation } },
+        { provide: Location, useValue: { back: jasmine.createSpy('back') } },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(BookmarkResultComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display the thank you message', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Thank you for your submission');
+    expect(compiled.textContent).toContain('Test Bookmark');
+    expect(compiled.textContent).toContain('https://example.com');
+  });
+
+  it('should call location.back() when goBack is triggered', () => {
+    component.goBack();
+    const location = TestBed.inject(Location);
+    expect(location.back).toHaveBeenCalled();
   });
 });

--- a/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.ts
+++ b/src/app/features/bookmark/components/bookmark-result/bookmark-result.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { CommonModule, Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { Bookmark } from '../../bookmark.model';
+
+@Component({
+  selector: 'app-bookmark-result',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './bookmark-result.component.html',
+  styleUrls: ['./bookmark-result.component.css'],
+})
+export class BookmarkResultComponent {
+  bookmark: Bookmark | null = null;
+
+  // Constructor initializes the component with the router and location services.
+  // It retrieves the bookmark data passed through the router's navigation state.
+  // If no bookmark is found, it defaults to null.
+  constructor(private router: Router, private location: Location) {
+    const nav = this.router.getCurrentNavigation();
+    this.bookmark = nav?.extras?.state?.['bookmark'] ?? null;
+  }
+
+  // Method to navigate back to the previous page using Angular's Location service.
+  goBack(): void {
+    this.location.back();
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to display a result page after a bookmark is submitted. It includes updates to the routing, bookmark form component, and the addition of a new result component. Below are the key changes grouped by theme:

### Routing Updates:
* Added a new route for the `BookmarkResultComponent` in `src/app/app.routes.ts`. This allows navigation to the result page after a bookmark is submitted.

### Bookmark Form Enhancements:
* Injected the `Router` service into the `BookmarkFormComponent` to enable navigation to the result page upon form submission. [[1]](diffhunk://#diff-3df1a07e5124a18ad9d3a02c2eaed1f969d05c9bd0f142eb3dd38f21fb8fefcbR12) [[2]](diffhunk://#diff-3df1a07e5124a18ad9d3a02c2eaed1f969d05c9bd0f142eb3dd38f21fb8fefcbL27-R33)
* Updated the `onSubmit` method in `BookmarkFormComponent` to navigate to the `/result` route and pass the submitted bookmark data via the router's state.

### New Bookmark Result Component:
* Created a new standalone `BookmarkResultComponent` to display the details of the submitted bookmark. It retrieves the bookmark data from the router's navigation state and provides a "Back" button to return to the previous page.
* Added a corresponding HTML template for `BookmarkResultComponent` to show the bookmark details or a fallback message if no data is available.
* Introduced unit tests for `BookmarkResultComponent` to ensure it initializes correctly.